### PR TITLE
feat: setup - storage layer

### DIFF
--- a/2. IaC/README.md
+++ b/2. IaC/README.md
@@ -9,11 +9,12 @@ Frontend: CloudFront → S3(* 정적 웹사이트)
 Backend: API Gateway → Lambda → Bedrock → S3(* 파일 저장)
 ```
 
-## 현재 구성 (Foundation Layer)
+## 현재 구성 (Foundation + Storage Layer)
 
 ### 리소스
 - **S3 버킷 (Frontend)**: 정적 웹사이트 호스팅용
 - **S3 버킷 (Backend)**: Bedrock 생성 파일 저장용
+- **CloudFront**: CDN 배포, HTTPS 리다이렉트, 캐싱 설정
 - **IAM 역할**: Lambda 실행 역할 (Bedrock, S3 접근 권한 포함)
 
 ### 파일 구조
@@ -80,11 +81,10 @@ terraform apply destroy.tfplan
 
 ## 다음 단계 (예정)
 
-1. **Storage Layer**: CloudFront 배포, S3 정책 설정
-2. **Compute Layer**: Lambda 함수, API Gateway 설정
-3. **AI Layer**: Bedrock 모델 연동
-4. **Security Layer**: WAF, 추가 보안 정책
-5. **Monitoring Layer**: CloudWatch, 로깅 설정
+1. **Compute Layer**: Lambda 함수, API Gateway 설정
+2. **AI Layer**: Bedrock 모델 연동
+3. **Security Layer**: WAF, 추가 보안 정책
+4. **Monitoring Layer**: CloudWatch, 로깅 설정
 
 ## 주의사항
 
@@ -112,5 +112,7 @@ terraform apply destroy.tfplan
 | `frontend_bucket_name` | 프론트엔드 S3 버킷명 |
 | `frontend_bucket_website_endpoint` | 프론트엔드 웹사이트 엔드포인트 |
 | `backend_bucket_name` | 백엔드 S3 버킷명 |
+| `cloudfront_distribution_id` | CloudFront 배포 ID |
+| `cloudfront_domain_name` | CloudFront 도메인명 (CDN URL) |
 | `lambda_role_arn` | Lambda 실행 역할 ARN |
 | `lambda_role_name` | Lambda 실행 역할명 |

--- a/2. IaC/main.tf
+++ b/2. IaC/main.tf
@@ -67,6 +67,58 @@ resource "aws_s3_bucket_policy" "frontend" {
   depends_on = [aws_s3_bucket_public_access_block.frontend]
 }
 
+# CloudFront Distribution for Frontend
+resource "aws_cloudfront_distribution" "frontend" {
+  origin {
+    domain_name = aws_s3_bucket_website_configuration.frontend.website_endpoint
+    origin_id   = "S3-${aws_s3_bucket.frontend.bucket}"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+
+  default_cache_behavior {
+    allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "S3-${aws_s3_bucket.frontend.bucket}"
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl     = 0
+    default_ttl = 3600
+    max_ttl     = 86400
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  tags = {
+    Name = "${var.phase}-${var.prefix}-cloudfront"
+  }
+}
+
 # S3 Bucket for Backend (Bedrock Files)
 resource "aws_s3_bucket" "backend" {
   bucket = "${var.phase}-${var.prefix}-backend"

--- a/2. IaC/outputs.tf
+++ b/2. IaC/outputs.tf
@@ -22,3 +22,13 @@ output "lambda_role_name" {
   description = "Name of the Lambda execution role"
   value       = aws_iam_role.lambda_role.name
 }
+
+output "cloudfront_distribution_id" {
+  description = "CloudFront distribution ID"
+  value       = aws_cloudfront_distribution.frontend.id
+}
+
+output "cloudfront_domain_name" {
+  description = "CloudFront distribution domain name"
+  value       = aws_cloudfront_distribution.frontend.domain_name
+}


### PR DESCRIPTION
### 🎯 작업 개요
Foundation Layer에 CloudFront CDN 배포 추가로 Storage Layer 완성

### 📦 주요 구현 내용
**CloudFront Distribution:**
- S3 정적 웹사이트를 CDN으로 배포
- HTTPS 자동 리다이렉트 설정
- 캐싱 정책 구성 (기본 1시간, 최대 24시간)
- Gzip 압축 활성화
- IPv6 지원 활성화

**Origin 설정:**
- S3 웹사이트 엔드포인트를 Custom Origin으로 연결
- HTTP-only 프로토콜 정책 (S3 웹사이트 호스팅 특성)

**새로운 출력값:**
- `cloudfront_distribution_id`: 배포 관리 및 캐시 무효화용
- `cloudfront_domain_name`: 실제 CDN 접속 URL

### ✅ 검증 완료
- CloudFront 배포 성공 (5-15분 소요)
- HTTPS 리다이렉트 작동 확인
- 캐싱 동작 정상

### 🔗 접속 방법
```bash
# CDN URL 확인
terraform output cloudfront_domain_name

# 테스트 파일 업로드 후 접속
aws s3 cp index.html s3://dev-qqq-frontend/
```

### 🔄 다음 단계
Compute Layer (Lambda, API Gateway) 구현 예정

### 📷 사진
<img width="1230" height="299" alt="스크린샷 2025-09-05 233156" src="https://github.com/user-attachments/assets/b3893b1a-5095-437a-ab14-42034839bf40" />
<img width="1007" height="665" alt="스크린샷 2025-09-05 233010" src="https://github.com/user-attachments/assets/dbb72150-7df8-46f9-b807-c11eb98dc822" />
