### PR TITLE
feat: setup - compute layer

### DIFF
--- a/2. IaC/.gitignore
+++ b/2. IaC/.gitignore
@@ -20,3 +20,6 @@ Thumbs.db
 .idea/
 *.swp
 *.swo
+
+# etcs
+*.zip

--- a/2. IaC/README.md
+++ b/2. IaC/README.md
@@ -9,12 +9,14 @@ Frontend: CloudFront → S3(* 정적 웹사이트)
 Backend: API Gateway → Lambda → Bedrock → S3(* 파일 저장)
 ```
 
-## 현재 구성 (Foundation + Storage Layer)
+## 현재 구성 (Foundation + Storage + Compute Layer)
 
 ### 리소스
 - **S3 버킷 (Frontend)**: 정적 웹사이트 호스팅용
 - **S3 버킷 (Backend)**: Bedrock 생성 파일 저장용
 - **CloudFront**: CDN 배포, HTTPS 리다이렉트, 캐싱 설정
+- **Lambda 함수**: API 처리 (Python 3.11, 1GB 메모리, 60초 타임아웃)
+- **API Gateway**: REST API (3개 엔드포인트, CORS 설정)
 - **IAM 역할**: Lambda 실행 역할 (Bedrock, S3 접근 권한 포함)
 
 ### 파일 구조
@@ -63,7 +65,26 @@ terraform state list
 terraform output
 ```
 
-### 4. 리소스 삭제
+### 4. API 테스트
+```bash
+# API Gateway URL 확인
+terraform output api_gateway_url
+
+# 엔드포인트 테스트 (curl)
+curl -X POST $(terraform output -raw api_gateway_url)/generate/text \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Hello World"}'
+
+# 브라우저 개발자 도구에서 테스트
+# F12 → Console에서 실행:
+# fetch('API_URL/generate/text', {
+#   method: 'POST',
+#   headers: { 'Content-Type': 'application/json' },
+#   body: JSON.stringify({ prompt: 'Hello World' })
+# }).then(r => r.json()).then(console.log)
+```
+
+### 5. 리소스 삭제
 ```bash
 # S3 버킷 비우기 (필요시)
 aws s3 rm s3://<bucket_name> --recursive
@@ -79,18 +100,42 @@ terraform apply destroy.tfplan
 - **개발 환경**: `terraform destroy`
 - **프로덕션**: `terraform plan -destroy` → 검토 → `terraform apply` (안전)
 
+## 백엔드 개발자를 위한 정보
+
+### Lambda 환경 변수
+- `S3_BUCKET_NAME`: 백엔드 파일 저장용 S3 버킷
+- `ENVIRONMENT`: 현재 환경 (dev/staging/prod)
+- `BEDROCK_TEXT_MODEL_ID`: amazon.titan-text-premier-v1:0
+- `BEDROCK_IMAGE_MODEL_ID`: amazon.titan-image-generator-v1
+
+### 코드 배포 방법
+```bash
+# AWS CLI로 Lambda 코드 업데이트
+aws lambda update-function-code \
+  --function-name $(terraform output -raw lambda_function_name) \
+  --zip-file fileb://deployment.zip
+```
+
+## API 엔드포인트
+
+| 엔드포인트 | 메서드 | 용도 | Bedrock 모델 |
+|------------|--------|------|-------------|
+| `/generate/text` | POST | 텍스트 생성 | amazon.titan-text-premier-v1:0 |
+| `/generate/image` | POST | 이미지 생성 | amazon.titan-image-generator-v1 |
+| `/generate/voice` | POST | 음성 생성 | 미정 |
+
 ## 다음 단계 (예정)
 
-1. **Compute Layer**: Lambda 함수, API Gateway 설정
-2. **AI Layer**: Bedrock 모델 연동
-3. **Security Layer**: WAF, 추가 보안 정책
-4. **Monitoring Layer**: CloudWatch, 로깅 설정
+1. **AI Layer**: Bedrock 모델 연동 및 실제 코드 구현
+2. **Security Layer**: WAF, 추가 보안 정책
+3. **Monitoring Layer**: CloudWatch, 로깅 설정
 
 ## 주의사항
 
 - `terraform.tfvars` 파일은 민감한 정보를 포함할 수 있으므로 Git에 커밋하지 마세요
 - AWS 자격 증명이 올바르게 설정되어 있는지 확인하세요
 - 리소스 삭제 시 `terraform destroy` 명령어를 사용하세요
+- **API 테스트**: 브라우저 주소창에서 GET 요청 시 "Missing Authentication Token" 메시지는 정상입니다 (POST 요청만 허용)
 
 ## 변수 설명
 
@@ -99,6 +144,8 @@ terraform apply destroy.tfplan
 | `aws_region` | AWS 리전 | `us-east-1` |
 | `phase` | 개발 단계 (dev/staging/prod) | `dev` |
 | `prefix` | 리소스 이름 접두사 | `qqq` |
+| `lambda_memory_size` | Lambda 메모리 크기 (MB) | `1024` |
+| `lambda_timeout` | Lambda 타임아웃 (초) | `60` |
 
 ## 리소스 명명 규칙
 
@@ -114,5 +161,7 @@ terraform apply destroy.tfplan
 | `backend_bucket_name` | 백엔드 S3 버킷명 |
 | `cloudfront_distribution_id` | CloudFront 배포 ID |
 | `cloudfront_domain_name` | CloudFront 도메인명 (CDN URL) |
+| `api_gateway_url` | API Gateway 호출 URL |
+| `lambda_function_name` | Lambda 함수명 |
 | `lambda_role_arn` | Lambda 실행 역할 ARN |
 | `lambda_role_name` | Lambda 실행 역할명 |

--- a/2. IaC/main.tf
+++ b/2. IaC/main.tf
@@ -197,3 +197,330 @@ resource "aws_iam_role_policy" "s3_backend_policy" {
     ]
   })
 }
+
+# Dummy Lambda deployment package
+data "archive_file" "lambda_zip" {
+  type        = "zip"
+  output_path = "lambda_function.zip"
+  source {
+    content  = <<EOF
+import json
+import os
+
+def lambda_handler(event, context):
+    return {
+        'statusCode': 200,
+        'headers': {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'POST, OPTIONS',
+            'Access-Control-Allow-Headers': 'Content-Type, Authorization'
+        },
+        'body': json.dumps({
+            'message': 'Hello from Lambda!',
+            'path': event.get('path', ''),
+            'method': event.get('httpMethod', ''),
+            'environment': os.environ.get('ENVIRONMENT', 'unknown')
+        })
+    }
+EOF
+    filename = "lambda_function.py"
+  }
+}
+
+# Lambda Function for API
+resource "aws_lambda_function" "api" {
+  filename         = data.archive_file.lambda_zip.output_path
+  function_name    = "${var.phase}-${var.prefix}-api"
+  role             = aws_iam_role.lambda_role.arn
+  handler          = "lambda_function.lambda_handler"
+  runtime          = "python3.11"
+  memory_size      = var.lambda_memory_size
+  timeout          = var.lambda_timeout
+  source_code_hash = data.archive_file.lambda_zip.output_base64sha256
+
+  environment {
+    variables = {
+      S3_BUCKET_NAME         = aws_s3_bucket.backend.bucket
+      ENVIRONMENT            = var.phase
+      BEDROCK_TEXT_MODEL_ID  = "amazon.titan-text-premier-v1:0"
+      BEDROCK_IMAGE_MODEL_ID = "amazon.titan-image-generator-v1"
+    }
+  }
+
+  tags = {
+    Name = "${var.phase}-${var.prefix}-api"
+  }
+}
+
+# API Gateway REST API
+resource "aws_api_gateway_rest_api" "api" {
+  name        = "${var.phase}-${var.prefix}-api"
+  description = "API Gateway for Quokka-core Mindset"
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+
+  tags = {
+    Name = "${var.phase}-${var.prefix}-api"
+  }
+}
+
+# API Gateway Resource: /generate
+resource "aws_api_gateway_resource" "generate" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  parent_id   = aws_api_gateway_rest_api.api.root_resource_id
+  path_part   = "generate"
+}
+
+# API Gateway Resource: /generate/text
+resource "aws_api_gateway_resource" "generate_text" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  parent_id   = aws_api_gateway_resource.generate.id
+  path_part   = "text"
+}
+
+# API Gateway Resource: /generate/image
+resource "aws_api_gateway_resource" "generate_image" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  parent_id   = aws_api_gateway_resource.generate.id
+  path_part   = "image"
+}
+
+# API Gateway Resource: /generate/voice
+resource "aws_api_gateway_resource" "generate_voice" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  parent_id   = aws_api_gateway_resource.generate.id
+  path_part   = "voice"
+}
+
+# API Gateway Method: POST /generate/text
+resource "aws_api_gateway_method" "generate_text_post" {
+  rest_api_id   = aws_api_gateway_rest_api.api.id
+  resource_id   = aws_api_gateway_resource.generate_text.id
+  http_method   = "POST"
+  authorization = "NONE"
+}
+
+# API Gateway Method: POST /generate/image
+resource "aws_api_gateway_method" "generate_image_post" {
+  rest_api_id   = aws_api_gateway_rest_api.api.id
+  resource_id   = aws_api_gateway_resource.generate_image.id
+  http_method   = "POST"
+  authorization = "NONE"
+}
+
+# API Gateway Method: POST /generate/voice
+resource "aws_api_gateway_method" "generate_voice_post" {
+  rest_api_id   = aws_api_gateway_rest_api.api.id
+  resource_id   = aws_api_gateway_resource.generate_voice.id
+  http_method   = "POST"
+  authorization = "NONE"
+}
+
+# API Gateway Integration: /generate/text
+resource "aws_api_gateway_integration" "generate_text_integration" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  resource_id = aws_api_gateway_resource.generate_text.id
+  http_method = aws_api_gateway_method.generate_text_post.http_method
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.api.invoke_arn
+}
+
+# API Gateway Integration: /generate/image
+resource "aws_api_gateway_integration" "generate_image_integration" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  resource_id = aws_api_gateway_resource.generate_image.id
+  http_method = aws_api_gateway_method.generate_image_post.http_method
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.api.invoke_arn
+}
+
+# API Gateway Integration: /generate/voice
+resource "aws_api_gateway_integration" "generate_voice_integration" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  resource_id = aws_api_gateway_resource.generate_voice.id
+  http_method = aws_api_gateway_method.generate_voice_post.http_method
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.api.invoke_arn
+}
+
+# CORS OPTIONS Methods
+resource "aws_api_gateway_method" "generate_text_options" {
+  rest_api_id   = aws_api_gateway_rest_api.api.id
+  resource_id   = aws_api_gateway_resource.generate_text.id
+  http_method   = "OPTIONS"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_method" "generate_image_options" {
+  rest_api_id   = aws_api_gateway_rest_api.api.id
+  resource_id   = aws_api_gateway_resource.generate_image.id
+  http_method   = "OPTIONS"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_method" "generate_voice_options" {
+  rest_api_id   = aws_api_gateway_rest_api.api.id
+  resource_id   = aws_api_gateway_resource.generate_voice.id
+  http_method   = "OPTIONS"
+  authorization = "NONE"
+}
+
+# CORS OPTIONS Integrations
+resource "aws_api_gateway_integration" "generate_text_options_integration" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  resource_id = aws_api_gateway_resource.generate_text.id
+  http_method = aws_api_gateway_method.generate_text_options.http_method
+  type        = "MOCK"
+
+  request_templates = {
+    "application/json" = "{\"statusCode\": 200}"
+  }
+}
+
+resource "aws_api_gateway_integration" "generate_image_options_integration" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  resource_id = aws_api_gateway_resource.generate_image.id
+  http_method = aws_api_gateway_method.generate_image_options.http_method
+  type        = "MOCK"
+
+  request_templates = {
+    "application/json" = "{\"statusCode\": 200}"
+  }
+}
+
+resource "aws_api_gateway_integration" "generate_voice_options_integration" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  resource_id = aws_api_gateway_resource.generate_voice.id
+  http_method = aws_api_gateway_method.generate_voice_options.http_method
+  type        = "MOCK"
+
+  request_templates = {
+    "application/json" = "{\"statusCode\": 200}"
+  }
+}
+
+# CORS Method Responses
+resource "aws_api_gateway_method_response" "generate_text_options_200" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  resource_id = aws_api_gateway_resource.generate_text.id
+  http_method = aws_api_gateway_method.generate_text_options.http_method
+  status_code = "200"
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = true
+    "method.response.header.Access-Control-Allow-Methods" = true
+    "method.response.header.Access-Control-Allow-Origin"  = true
+  }
+}
+
+resource "aws_api_gateway_method_response" "generate_image_options_200" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  resource_id = aws_api_gateway_resource.generate_image.id
+  http_method = aws_api_gateway_method.generate_image_options.http_method
+  status_code = "200"
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = true
+    "method.response.header.Access-Control-Allow-Methods" = true
+    "method.response.header.Access-Control-Allow-Origin"  = true
+  }
+}
+
+resource "aws_api_gateway_method_response" "generate_voice_options_200" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  resource_id = aws_api_gateway_resource.generate_voice.id
+  http_method = aws_api_gateway_method.generate_voice_options.http_method
+  status_code = "200"
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = true
+    "method.response.header.Access-Control-Allow-Methods" = true
+    "method.response.header.Access-Control-Allow-Origin"  = true
+  }
+}
+
+# CORS Integration Responses
+resource "aws_api_gateway_integration_response" "generate_text_options_integration_response" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  resource_id = aws_api_gateway_resource.generate_text.id
+  http_method = aws_api_gateway_method.generate_text_options.http_method
+  status_code = aws_api_gateway_method_response.generate_text_options_200.status_code
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization'"
+    "method.response.header.Access-Control-Allow-Methods" = "'POST,OPTIONS'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+  }
+}
+
+resource "aws_api_gateway_integration_response" "generate_image_options_integration_response" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  resource_id = aws_api_gateway_resource.generate_image.id
+  http_method = aws_api_gateway_method.generate_image_options.http_method
+  status_code = aws_api_gateway_method_response.generate_image_options_200.status_code
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization'"
+    "method.response.header.Access-Control-Allow-Methods" = "'POST,OPTIONS'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+  }
+}
+
+resource "aws_api_gateway_integration_response" "generate_voice_options_integration_response" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  resource_id = aws_api_gateway_resource.generate_voice.id
+  http_method = aws_api_gateway_method.generate_voice_options.http_method
+  status_code = aws_api_gateway_method_response.generate_voice_options_200.status_code
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization'"
+    "method.response.header.Access-Control-Allow-Methods" = "'POST,OPTIONS'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+  }
+}
+
+# Lambda Permission for API Gateway
+resource "aws_lambda_permission" "api_gateway_lambda" {
+  statement_id  = "AllowExecutionFromAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.api.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.api.execution_arn}/*/*"
+}
+
+# API Gateway Deployment
+resource "aws_api_gateway_deployment" "api" {
+  depends_on = [
+    aws_api_gateway_integration.generate_text_integration,
+    aws_api_gateway_integration.generate_image_integration,
+    aws_api_gateway_integration.generate_voice_integration,
+    aws_api_gateway_integration_response.generate_text_options_integration_response,
+    aws_api_gateway_integration_response.generate_image_options_integration_response,
+    aws_api_gateway_integration_response.generate_voice_options_integration_response
+  ]
+
+  rest_api_id = aws_api_gateway_rest_api.api.id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# API Gateway Stage
+resource "aws_api_gateway_stage" "api" {
+  deployment_id = aws_api_gateway_deployment.api.id
+  rest_api_id   = aws_api_gateway_rest_api.api.id
+  stage_name    = var.phase
+
+  tags = {
+    Name = "${var.phase}-${var.prefix}-api-stage"
+  }
+}

--- a/2. IaC/outputs.tf
+++ b/2. IaC/outputs.tf
@@ -32,3 +32,13 @@ output "cloudfront_domain_name" {
   description = "CloudFront distribution domain name"
   value       = aws_cloudfront_distribution.frontend.domain_name
 }
+
+output "api_gateway_url" {
+  description = "API Gateway invoke URL"
+  value       = "https://${aws_api_gateway_rest_api.api.id}.execute-api.${var.aws_region}.amazonaws.com/${var.phase}"
+}
+
+output "lambda_function_name" {
+  description = "Lambda function name"
+  value       = aws_lambda_function.api.function_name
+}

--- a/2. IaC/terraform.tfvars.example
+++ b/2. IaC/terraform.tfvars.example
@@ -3,3 +3,7 @@
 aws_region = "us-east-1"
 phase      = "dev"
 prefix     = "qqq"
+
+# Lambda Configuration
+lambda_memory_size = 1024
+lambda_timeout     = 60

--- a/2. IaC/variables.tf
+++ b/2. IaC/variables.tf
@@ -15,3 +15,15 @@ variable "prefix" {
   type        = string
   default     = "qqq"
 }
+
+variable "lambda_memory_size" {
+  description = "Lambda function memory size in MB"
+  type        = number
+  default     = 1024
+}
+
+variable "lambda_timeout" {
+  description = "Lambda function timeout in seconds"
+  type        = number
+  default     = 60
+}


### PR DESCRIPTION
### 🎯 작업 개요
AWS 서버리스 아키텍처의 Compute Layer 구성으로 Lambda 함수와 API Gateway 추가

### 📦 주요 구현 내용
**Lambda 함수:**
```tf
resource "aws_lambda_function" "api" {
  function_name = "${var.phase}-${var.prefix}-api"
  runtime       = "python3.11"
  memory_size   = 1024
  timeout       = 60
  
  environment {
    variables = {
      S3_BUCKET_NAME           = aws_s3_bucket.backend.bucket
      ENVIRONMENT              = var.phase
      BEDROCK_TEXT_MODEL_ID    = "amazon.titan-text-premier-v1:0"
      BEDROCK_IMAGE_MODEL_ID   = "amazon.titan-image-generator-v1"
    }
  }
}
```

**API Gateway 엔드포인트:**

```
# 3개 엔드포인트 구성
POST /generate/text   → amazon.titan-text-premier-v1:0
POST /generate/image  → amazon.titan-image-generator-v1
POST /generate/voice  → 없음 (미사용)
```

**CORS 설정:**
- 모든 오리진 허용 (*) - 개발 환경용
- POST, OPTIONS 메서드 지원
- Content-Type, Authorization 헤더 허용

### ✅ 검증 완료
- Terraform 배포 성공
- API Gateway 엔드포인트 정상 작동 확인
- Lambda 더미 함수 응답 테스트 완료
- CORS preflight 요청 처리 확인

### 🔗 테스트 방법
```bash
# API URL 확인
terraform output api_gateway_url

# 엔드포인트 테스트
curl -X POST $(terraform output -raw api_gateway_url)/generate/text \
  -H "Content-Type: application/json" \
  -d '{"prompt": "Hello World"}'
```

### 📋 백엔드 팀 지원
- Lambda 배포 가이드 문서 작성 (Lambda-Deployment-Guide.md)
- 환경 변수 자동 설정 (S3 버킷명, Bedrock 모델 ID 등)
- AWS CLI 기반 코드 업데이트 방법 제공

### 🔄 다음 단계
AI Layer - 실제 Bedrock 연동 코드 구현 및 배포